### PR TITLE
Fix CMake executable sources

### DIFF
--- a/so-cube/CMakeLists.txt
+++ b/so-cube/CMakeLists.txt
@@ -4,8 +4,9 @@ project(so_cube)
 set(CMAKE_CXX_STANDARD 20)
 find_package(SFML 2.5 COMPONENTS system graphics audio REQUIRED)
 
-add_executable(so_cube main.cpp
-        camstream.h
-        Polygon.h)
+add_executable(so_cube main.cpp)
+
+target_include_directories(so_cube PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_features(so_cube PRIVATE cxx_std_20)
 
 target_link_libraries(so_cube sfml-system sfml-graphics sfml-audio)


### PR DESCRIPTION
## Summary
- remove headers from the `add_executable` source list
- add an include directory and compile features for the cube project

## Testing
- `cmake ../so-cube` *(fails: could not find SFML)*
- `make -j4` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68473f241d308332af3e757d8868582e