### PR TITLE
Remove unused rotate declaration

### DIFF
--- a/so-cube/main.cpp
+++ b/so-cube/main.cpp
@@ -14,8 +14,6 @@ bool compare(const Polygon &left, const Polygon &right) {
     return left > right;
 }
 
-[[maybe_unused]] void rotate(vector<Polygon>& v, float delta);
-
 int main() {
     vector<Color> colors = {Color::White, Color::Red, Color::Yellow, Color(255, 165, 0, 255), Color::Green, Color::Blue};
     vector<vector<Vector3f>> vv(9, vector<Vector3f>(4));


### PR DESCRIPTION
## Summary
- trim the unused rotate function declaration from `main.cpp`

## Testing
- `cmake ..` *(fails: could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68473f2284288332a18ee7072504f1bc