### PR TITLE
Improve README with build and usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# cube
+# Cube
+
+This project is a small 3D cube simulation built with C++ and [SFML](https://www.sfml-dev.org/). It renders a cube whose faces can be rotated using the keyboard.
+
+## Building
+
+1. Install SFML (version 2.5 or newer).
+2. Generate the build files with CMake:
+   ```bash
+   cmake -S so-cube -B build
+   ```
+3. Build the executable:
+   ```bash
+   cmake --build build
+   ```
+4. Run the program:
+   ```bash
+   ./build/so_cube
+   ```
+
+## Controls
+
+- **Arrow keys** &ndash; move the cube on the X and Y axes.
+- **`=` / `-`** &ndash; move the cube along the Z axis.
+- **`1`/`2`** &ndash; rotate around the X axis.
+- **`3`/`4`** &ndash; rotate around the Y axis.
+- **`5`/`6`** &ndash; rotate around the Z axis.
+- **`F` / `G`** &ndash; rotate the front face.
+- **`B` / `N`** &ndash; rotate the back face.
+- **`U` / `I`** &ndash; rotate the top face.
+- **`D` / `S`** &ndash; rotate the bottom face.
+- **`R` / `T`** &ndash; rotate the right face.
+- **`L` / `K`** &ndash; rotate the left face.
+


### PR DESCRIPTION
## Summary
- document project purpose in README
- add build steps using CMake and SFML
- list keyboard controls for moving and rotating the cube

## Testing
- `cmake -S so-cube -B build` *(fails: Could not find a package configuration file provided by "SFML")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68473f2606b483329919a289006d2cbf